### PR TITLE
Fixed if logic.

### DIFF
--- a/Core/Source/DTMarkdownParser.m
+++ b/Core/Source/DTMarkdownParser.m
@@ -98,7 +98,7 @@ NSString * const DTMarkdownParserSpecialTagBlockquote = @"BLOCKQUOTE";
 
 - (void)_reportEndOfTag:(NSString *)tag
 {
-	if (_delegateFlags.supportsStartTag)
+	if (_delegateFlags.supportsEndTag)
 	{
 		[_delegate parser:self didEndElement:tag];
 	}


### PR DESCRIPTION
 Checking against start of tag report support when reporting end of tag.
