### PR TITLE
Add optional URL detection

### DIFF
--- a/Core/Source/DTMarkdownParser.h
+++ b/Core/Source/DTMarkdownParser.h
@@ -86,6 +86,11 @@ typedef NS_ENUM(NSUInteger, DTMarkdownParserOptions)
 @property (nonatomic, DT_WEAK_PROPERTY) id <DTMarkdownParserDelegate> delegate;
 
 /**
+ Turns automatic URL/link detection on or off. Default value is YES.
+ */
+@property (nonatomic, assign) BOOL detectURLs;
+
+/**
  Starts the event-driven parsing operation.
  @returns `YES` if parsing is successful and `NO` in there is an error or if the parsing operation is aborted.
  */

--- a/Core/Source/DTMarkdownParser.m
+++ b/Core/Source/DTMarkdownParser.m
@@ -65,6 +65,7 @@ NSString * const DTMarkdownParserSpecialTagBlockquote = @"BLOCKQUOTE";
 		
 		// default detector
 		_dataDetector = [NSDataDetector dataDetectorWithTypes:(NSTextCheckingTypes)NSTextCheckingTypeLink error:NULL];
+        _detectURLs = YES;
 	}
 	
 	return self;
@@ -777,7 +778,7 @@ NSString * const DTMarkdownParserSpecialTagBlockquote = @"BLOCKQUOTE";
 // process characters and optionally auto-detect links
 - (void)_processCharacters:(NSString *)string inRange:(NSRange)range allowAutodetection:(BOOL)allowAutodetection
 {
-	if (!allowAutodetection || !_dataDetector)
+	if (!allowAutodetection || !_dataDetector || !self.detectURLs)
 	{
 		[self _reportCharacters:string];
 		return;


### PR DESCRIPTION
Link detection should be optional as it is not always desirable and may cause issues if links are detected in non-body elements.